### PR TITLE
FIX/21

### DIFF
--- a/GGJ26/Assets/01. Scripts/Network/StunGun.cs
+++ b/GGJ26/Assets/01. Scripts/Network/StunGun.cs
@@ -352,25 +352,36 @@ public class StunGun : NetworkBehaviour
 
     private void HandleHit(RaycastHit hit)
     {
+        // --- Player branch ---
         var target = hit.collider.GetComponentInParent<PlayerElimination>();
-        if (target == null)
+        if (target != null)
         {
-            var npc = hit.collider.GetComponentInParent<BaseNPC>();
-            if (npc != null)
+            if (target.IsEliminated)
             {
-                var npcController = npc.GetComponent<NPCController>();
-                if (npcController != null)
-                {
-                    npcController.RpcTriggerDead();
-                }
-                RpcSpawnFogEffect(npc.transform.position, npc.transform.rotation);
+                return;
             }
+
+            target.RpcRequestPlayDeadAnimation();
+            target.RpcRequestEliminate();
+            target.ApplyEliminatedStateImmediate();
             return;
         }
 
-        target.RpcRequestPlayDeadAnimation();
-        target.RpcRequestEliminate();
-        target.ApplyEliminatedStateImmediate();
+        // --- NPC branch ---
+        var npc = hit.collider.GetComponentInParent<BaseNPC>();
+        if (npc == null)
+        {
+            return;
+        }
+
+        var npcController = npc.GetComponent<NPCController>();
+        if (npcController == null || npcController.IsDead)
+        {
+            return;
+        }
+
+        npcController.RpcTriggerDead();
+        RpcSpawnFogEffect(npc.transform.position, npc.transform.rotation);
     }
 
     [Rpc(RpcSources.InputAuthority, RpcTargets.StateAuthority)]


### PR DESCRIPTION
## Summary
- Added `IsEliminated` guard to prevent duplicate hit effects on already-eliminated players
- Moved `RpcSpawnFogEffect` inside `IsDead` guard to prevent duplicate fog on dead NPCs
- Refactored `HandleHit()` from nested if/else to flat early-return structure for clarity

## Test plan
- [x] Shoot an NPC → fog spawns once
- [x] Shoot the same dead NPC again → no fog, no effect
- [ ] Shoot an eliminated player → no effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)