### PR TITLE
feat(#37) : Add Unity CD workflow for automated releases

### DIFF
--- a/.github/workflows/unity-cd.yml
+++ b/.github/workflows/unity-cd.yml
@@ -1,0 +1,80 @@
+name: Unity CD
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    name: Build & Release (Windows)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Determine version info
+        id: version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+
+          if [[ "$TAG" == *"-preview"* ]]; then
+            IS_PRERELEASE=true
+            RELEASE_NAME="FindMask ${TAG} (Preview)"
+          else
+            IS_PRERELEASE=false
+            RELEASE_NAME="FindMask ${TAG}"
+          fi
+
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=${IS_PRERELEASE}" >> "$GITHUB_OUTPUT"
+          echo "release_name=${RELEASE_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Library
+        uses: actions/cache@v4
+        with:
+          path: GGJ26/Library
+          key: Library-${{ hashFiles('GGJ26/Assets/**', 'GGJ26/Packages/manifest.json', 'GGJ26/ProjectSettings/**') }}
+          restore-keys: |
+            Library-
+
+      - name: Build Unity project
+        uses: game-ci/unity-builder@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          projectPath: GGJ26
+          targetPlatform: StandaloneWindows64
+          unityVersion: auto
+          buildName: FindMask
+          versioning: custom
+          version: ${{ steps.version.outputs.version }}
+
+      - name: Zip build artifacts
+        run: |
+          cd build/StandaloneWindows64
+          zip -r "../../FindMask-${{ steps.version.outputs.version }}-Windows.zip" .
+          cd ../..
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ steps.version.outputs.release_name }}
+          prerelease: ${{ steps.version.outputs.is_prerelease }}
+          generate_release_notes: true
+          files: FindMask-${{ steps.version.outputs.version }}-Windows.zip


### PR DESCRIPTION
## Related Issue
closes #37

## Changes
- Created .github/workflows/unity-cd.yml
- Builds Windows x64 on v* tag push
- Supports stable (v1.0.0) and preview (v1.0.0-preview.1) releases
- Creates GitHub Release with zipped build artifacts
