### PR TITLE
CHORE/55

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+*.unity merge=unityyamlmerge
+*.prefab merge=unityyamlmerge
+*.asset merge=unityyamlmerge
+*.controller merge=unityyamlmerge
+*.anim merge=unityyamlmerge
+*.overrideController merge=unityyamlmerge
+*.physicMaterial merge=unityyamlmerge
+*.physicsMaterial2D merge=unityyamlmerge
+*.mat merge=unityyamlmerge
+*.mask merge=unityyamlmerge
+*.mesh merge=unityyamlmerge
+*.signal merge=unityyamlmerge
+*.playable merge=unityyamlmerge
+*.renderTexture merge=unityyamlmerge
+*.shadervariants merge=unityyamlmerge

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,34 @@
+$UNITY_VERSION = "6000.3.10f1"
+
+function Find-UnityMergeTool {
+    $candidate = "C:\Program Files\Unity\Hub\Editor\$UNITY_VERSION\Editor\Data\Tools\UnityYAMLMerge.exe"
+    if (Test-Path $candidate) { return $candidate }
+
+    $hubEditorPath = "C:\Program Files\Unity\Hub\Editor"
+    if (Test-Path $hubEditorPath) {
+        $found = Get-ChildItem $hubEditorPath -Directory |
+            ForEach-Object { "$($_.FullName)\Editor\Data\Tools\UnityYAMLMerge.exe" } |
+            Where-Object { Test-Path $_ } |
+            Select-Object -First 1
+        if ($found) { return $found }
+    }
+
+    return $null
+}
+
+$mergeTool = Find-UnityMergeTool
+
+if (-not $mergeTool) {
+    Write-Host "WARNING: UnityYAMLMerge not found."
+    Write-Host "Unity $UNITY_VERSION is not installed, or it is in a non-standard location."
+    Write-Host "Configure manually after installing Unity:"
+    Write-Host ""
+    Write-Host "  git config --local merge.unityyamlmerge.name `"Unity SmartMerge`""
+    Write-Host "  git config --local merge.unityyamlmerge.driver `"'<path to UnityYAMLMerge>' merge -p %O %B %A %P`""
+    Write-Host "  git config --local merge.unityyamlmerge.recursive binary"
+} else {
+    git config --local merge.unityyamlmerge.name "Unity SmartMerge"
+    git config --local merge.unityyamlmerge.driver "'$mergeTool' merge -p %O %B %A %P"
+    git config --local merge.unityyamlmerge.recursive binary
+    Write-Host "SmartMerge configured: $mergeTool"
+}


### PR DESCRIPTION
## Summary
- Unity SmartMerge(UnityYAMLMerge) 설정을 자동화하는 `setup.ps1` 스크립트 추가
- `.gitattributes`에 Unity 파일 확장자(`.unity`, `.prefab`, `.asset` 등)를 SmartMerge 드라이버에 매핑

## Test plan
- [x] `setup.ps1` 실행 후 `git config --local --list | grep merge` 로 드라이버 등록 확인
- [x] `.gitattributes` 내용 확인
- [x] Unity 파일 머지 충돌 시 SmartMerge 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)